### PR TITLE
ci: skip Claude code review for bot-authored PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,12 +12,10 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-    
+    # Skip bot-authored PRs (dependabot, etc.) — they don't need AI code review
+    # and the action will fail with "non-human actor" if they trigger it.
+    if: github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]'
+
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- Adds `if: github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]'` guard to the `claude-review` job in `claude-code-review.yml`
- Prevents the `anthropics/claude-code-action` from failing with _"Workflow initiated by non-human actor"_ when dependabot or automation creates a PR

## Motivation

Bot-authored PRs (routine dep bumps) don't benefit from AI code review. The Anthropic action already rejects them — this just makes that rejection explicit and clean instead of a workflow failure.

## Test plan

- [ ] Human-authored PRs still trigger Claude code review
- [ ] Bot-authored PRs skip the job cleanly with no failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)